### PR TITLE
Update gitattributes and gitignore to standardize line ending

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,13 @@
+# Ref: https://docs.github.com/en/get-started/git-basics/configuring-git-to-handle-line-endings
+
+# Set the default behavior, in case people don't have core.autocrlf set
+# * text=auto
+
+# Source code files set to LF ending
+*.java text eol=lf
+*.fxml text eol=lf
+*.css text eol=lf
+
+# Binary files
+*.class binary
 *.pdf binary

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ src/test/data/sandbox/
 .DS_Store
 docs/_site/
 docs/_markbind/logs/
+
+# Custom ignore files
+*.class
+*.old


### PR DESCRIPTION
Specifics
* java, fxml and css files enforced with LF endings
* ignored compiled java class files
* ignored old extension files